### PR TITLE
Set User-Agent header for HTTP requests

### DIFF
--- a/src/main/java/git/lfs/migrate/Main.java
+++ b/src/main/java/git/lfs/migrate/Main.java
@@ -81,6 +81,7 @@ public class Main {
   @NotNull
   private static Client createClient(@NotNull AuthProvider auth, @NotNull CmdArgs cmd) throws GeneralSecurityException {
     final HttpClientBuilder httpBuilder = HttpClients.custom();
+    httpBuilder.setUserAgent("git-lfs-migrate");
     if (cmd.noCheckCertificate) {
       httpBuilder.setSSLHostnameVerifier((hostname, session) -> true);
       httpBuilder.setSSLContext(SSLContexts.custom()


### PR DESCRIPTION
Some server implementations may check this. The official client uses
something like "git-lfs/1.2.0 (...)" with OS/arch and Go version in
parens.