### PR TITLE
Escape spaces in glob patterns

### DIFF
--- a/src/main/java/git/lfs/migrate/GitConverter.java
+++ b/src/main/java/git/lfs/migrate/GitConverter.java
@@ -393,7 +393,7 @@ public class GitConverter {
       public ObjectId convert(@NotNull Repository dstRepo, @NotNull ObjectInserter inserter, @NotNull ConvertResolver resolver, @Nullable Uploader uploader) throws IOException {
         final Set<String> attributes = new TreeSet<>();
         for (String glob : globs) {
-          attributes.add(glob + "\tfilter=lfs diff=lfs merge=lfs -text");
+          attributes.add(glob.replace(" ", "[[:space:]]") + "\tfilter=lfs diff=lfs merge=lfs -text");
         }
         final ByteArrayOutputStream blob = new ByteArrayOutputStream();
         try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(openAttributes(reader, id), StandardCharsets.UTF_8))) {


### PR DESCRIPTION
As per [`git lfs track` behaviour](https://github.com/git-lfs/git-lfs/blob/master/commands/command_track.go#L80)! :)